### PR TITLE
Issue-1: flatmap stream vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "inert": "^5.1.2",
     "mongoose": "^5.3.12",
     "nodemon": "^1.18.6",
-    "vision": "^5.4.3"
+    "vision": "^5.4.3",
+    "flatmap-stream":"3.3.4"
   }
 }


### PR DESCRIPTION
Downgraded to 3.3.4 for now.